### PR TITLE
FEAT Show IPV4 and IPV6

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -73,6 +73,7 @@ function generateHomeViewData(lang, ip, info) {
         'title' : i18next.t('title'), 
         'ip': ip, 
         'ipinfo' : info,
+        'ipinfo_domain' : ip.includes(':') ? 'ipinfo.io': 'v6.ipinfo.io',
         'home_description': i18next.t('home-description'),
         'html_lang': lang == 'en' ? 'en' : 'pt_BR',
         'your_current_ip': i18next.t('your-current-ip'),
@@ -134,7 +135,6 @@ app.get('/en', async (req, res) => {
     const ip = req.ip;
     getIPInfo((info) => {
         info = JSON.parse(info);
-
         var viewdata = generateHomeViewData('pt', ip, info);
 
         res.render('index', viewdata);

--- a/views/index.html
+++ b/views/index.html
@@ -88,13 +88,19 @@
 
 <script>
     const featchData = fetch("https://{{ ipinfo_domain }}?callback")
-        .then(response => response.json())
+        .then(response => { 
+            if (response.status !== 200) {
+                throw Error();
+            }
+            return response.json()})
         .then(data => {
             if (data.ip != "{{ ip }}" && data.ip != "") {
                 const newSpan = document.createElement('p');
                 newSpan.textContent = data.ip;
                 document.querySelector('.splash-head').appendChild(newSpan);
             }
+        }).catch(error => {
+            console.log("Could not obtain second IP");
         });
 </script>
 

--- a/views/index.html
+++ b/views/index.html
@@ -40,7 +40,7 @@
             
             <h2 class="second-title">{{ your_current_ip }}</h2>
             <div class="splash-head">
-                <span>{{ ip }}</span>
+                <p>{{ ip }}</p>
             </div>
             <br>
             <div class="pure-g ipinfo">
@@ -84,6 +84,18 @@
         localStorage.setItem('cookieConsent', 'accepted');
         document.getElementById('cookieConsentPopup').style.display = 'none';
     });
+</script>
+
+<script>
+    const featchData = fetch("https://{{ ipinfo_domain }}?callback")
+        .then(response => response.json())
+        .then(data => {
+            if (data.ip != "{{ ip }}" && data.ip != "") {
+                const newSpan = document.createElement('p');
+                newSpan.textContent = data.ip;
+                document.querySelector('.splash-head').appendChild(newSpan);
+            }
+        });
 </script>
 
 <!-- Place this tag in your head or just before your close body tag. -->


### PR DESCRIPTION
## Description

- If the user has a dual stack IP configuration, two IPs will now be displayed. Only the IP address that is actually connected can be obtained from the request.
- The first source of the IP address remains the same as the request source(localhost is displayed because it is running locally), and the second is to check the request source's IP format and try to obtain an IP in a different IP format for ipinfo.io.
- I only tested it in my local environment.

## Related Issue

https://github.com/hugodeaguiar/getip.dev/issues/2

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.